### PR TITLE
Set more accurate nonce

### DIFF
--- a/yobit.py
+++ b/yobit.py
@@ -84,7 +84,7 @@ class YoBit(object):
 
         request_url = BASE_TRADE
         options['method'] = method
-        options['nonce'] = str(int(time.time()))
+        options['nonce'] = str(int(time.time()*1000))
 
         body = urlencode(options)
 


### PR DESCRIPTION
In order to send messages more frequently than 1 per second we need nonce to be set more precicely. So we are taking in account milliseconds too.